### PR TITLE
chore: update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -46,7 +46,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
@@ -84,10 +84,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -106,7 +106,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
@@ -122,7 +122,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Select latest stable Xcode
         run: |
@@ -142,7 +142,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Read Flutter version
         id: flutter-version
@@ -178,7 +178,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Determine version to deploy
         id: version
@@ -147,7 +147,7 @@ jobs:
 
       - name: Download web artifact from current run
         if: ${{ inputs.artifact_run_id != '' }}
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: helium-${{ inputs.specific_version }}-web
           path: ./web-build
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Determine version to deploy
         id: version
@@ -367,7 +367,7 @@ jobs:
 
       - name: Download Android artifact from current run
         if: ${{ inputs.artifact_run_id != '' }}
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: helium-${{ inputs.specific_version }}-android.aab
           path: ./android-build
@@ -436,7 +436,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Determine version to deploy
         id: version
@@ -509,7 +509,7 @@ jobs:
 
       - name: Download iOS artifact from current run
         if: ${{ inputs.artifact_run_id != '' }}
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: helium-${{ inputs.specific_version }}-ios.ipa
           path: ./ios-build

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -82,7 +82,7 @@ jobs:
       PLATFORM: amd64
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Read Flutter version
         id: flutter-version
@@ -96,7 +96,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: Cache ChromeDriver
         id: cache-chromedriver
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /usr/local/bin/chromedriver
           key: ${{ runner.os }}-chromedriver-${{ steps.chrome-version.outputs.version }}
@@ -212,7 +212,7 @@ jobs:
 
       - name: Upload screenshots
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: integration-screenshots
           path: build/integration-screenshots/

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -14,7 +14,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,10 +38,10 @@ jobs:
       PLAYWRIGHT_SMOKE_TEST_PASSWORD: ${{ secrets.PLAYWRIGHT_SMOKE_TEST_PASSWORD }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -56,7 +56,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-screenshots
           path: playwright/screenshots/

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -33,7 +33,7 @@ jobs:
       commit_sha: ${{ steps.commit_lockfiles.outputs.commit_sha }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ github.actor == 'dependabot[bot]' && secrets.GITHUB_TOKEN || secrets.PERSONAL_ACCESS_TOKEN }}
           ref: ${{ inputs.ref || 'main' }}
@@ -50,7 +50,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
       base_sha: ${{ steps.create_branch.outputs.base_sha }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           ref: ${{ github.sha }}
@@ -109,12 +109,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs['create-release-branch'].outputs.base_sha }}
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -133,7 +133,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
@@ -173,7 +173,7 @@ jobs:
       commit_sha: ${{ steps.get_commit.outputs.commit_sha }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           ref: ${{ needs['refresh-lockfiles'].outputs.commit_sha }}
@@ -190,7 +190,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
@@ -246,7 +246,7 @@ jobs:
       merged_commit_sha: ${{ steps.merge.outputs.merged_commit_sha }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           ref: main
@@ -294,12 +294,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs['merge-release-branch'].outputs.merged_commit_sha }}
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -318,7 +318,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
@@ -351,7 +351,7 @@ jobs:
           SENTRY_PROPERTIES=sentry.properties sentry-cli debug-files upload build/symbols/
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: helium-${{ needs['bump-version'].outputs.version }}-android.aab
           path: build/app/outputs/bundle/release/app-release.aab
@@ -368,7 +368,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs['merge-release-branch'].outputs.merged_commit_sha }}
 
@@ -390,7 +390,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
@@ -463,7 +463,7 @@ jobs:
           SENTRY_PROPERTIES=sentry.properties sentry-cli debug-files upload build/symbols/ build/ios/archive/Runner.xcarchive/dSYMs/
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: helium-${{ needs['bump-version'].outputs.version }}-ios.ipa
           path: build/ios/ipa/Helium.ipa
@@ -482,7 +482,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs['merge-release-branch'].outputs.merged_commit_sha }}
 
@@ -498,7 +498,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
@@ -533,7 +533,7 @@ jobs:
             build/web
 
       - name: Upload web artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: helium-${{ needs['bump-version'].outputs.version }}-web
           path: build/web
@@ -554,7 +554,7 @@ jobs:
       ENVIRONMENT: prod
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs['merge-release-branch'].outputs.merged_commit_sha }}
 
@@ -579,7 +579,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4/v5 to v6
- Update `actions/setup-java` from v4 to v5
- Update `actions/setup-python` from v5 to v6
- Update `actions/cache` from v4 to v5
- Update `actions/upload-artifact` from v4 to v7
- Update `actions/download-artifact` from v5 to v8

These updates ensure compatibility with GitHub Actions runners using Node 24, as older action versions are deprecated and will stop working.

## Test plan
- [ ] Verify build workflow passes
- [ ] Verify release workflow passes (can test with a dry run)
- [ ] Verify integration tests work
- [ ] Verify playwright tests work