### PR TITLE
chore: update remaining actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,7 +171,7 @@ jobs:
           ls -la ./web-build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -127,7 +127,7 @@ jobs:
       # dev-local: Login to ECR to avoid rate limits
       - name: Configure AWS credentials (dev-local only)
         if: ${{ inputs.environment == 'dev-local' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -559,7 +559,7 @@ jobs:
           ref: ${{ needs['merge-release-branch'].outputs.merged_commit_sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to AWS ECR Public
         run: |


### PR DESCRIPTION
## Summary
- Update `aws-actions/configure-aws-credentials` from v4 to v6 in deploy.yml
- Update `aws-actions/configure-aws-credentials` from v4 to v6 in integration.yml
- Update `docker/setup-buildx-action` from v3 to v4 in release.yml

These actions were still using Node 20, which will be deprecated in GitHub Actions.